### PR TITLE
Fix incorrect filename for HTML reporting 

### DIFF
--- a/R/auto-qc.R
+++ b/R/auto-qc.R
@@ -153,6 +153,8 @@ flow_auto_qc <- function(fcsfiles, remove_from = "all",
 
     filename_ext <- description(set[[i]])$FILENAME
     filename <- sub("^([^.]*).*", "\\1", filename_ext)
+    filename <- basename(filename)
+    samplename <- description(set[[i]])$`$FIL`
     if (html_report != FALSE) {
         reportfile <- paste0(getwd(), .Platform$file.sep, 
             ifelse(folder_results != FALSE, paste0(folder_results, .Platform$file.sep), ""),

--- a/inst/rmd/autoQC_report.Rmd
+++ b/inst/rmd/autoQC_report.Rmd
@@ -13,7 +13,7 @@ opts_chunk$set(fig.align='center', out.width='750px', dpi=200)  #out.width='750p
 
 ## FCS file information
 
-> Input file name: `r filename`    
+> Input file name: `r samplename`    
 > Number of events: `r as.integer(dim(set[[i]])[1])`
 
 ```{r, echo=FALSE, fig.height = 3}


### PR DESCRIPTION
1. Fix a bug in exporting html report, the filename has current working directory+ file full path + filename, need to remove the folder path of the FCS files

2. Use `$FIL` keyword in FCS file as the name for HTML report, rather than file name. This avoid showing name that is modified by Galaxy or user